### PR TITLE
Switch dependency to backbone-on-rails which is actively developed

### DIFF
--- a/backtastic.gemspec
+++ b/backtastic.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   
   s.add_runtime_dependency "haml_coffee_assets"
-  s.add_runtime_dependency "rails-backbone"
+  s.add_runtime_dependency "backbone-on-rails"
   s.add_runtime_dependency "inflection-js-rails"
   s.add_runtime_dependency "twitter-bootstrap-rails"
   s.add_runtime_dependency "activesupport"

--- a/lib/backtastic.rb
+++ b/lib/backtastic.rb
@@ -1,5 +1,5 @@
 require "backtastic/version"
-require 'rails-backbone'
+require 'backbone-on-rails'
 require "inflection-js-rails"
 require "twitter-bootstrap-rails"
 require "active_support/inflections"


### PR DESCRIPTION
backbone-on-rails is actively developed and has version 1.0.0 for example, whereas the current dependency rails-backbone is now an inactive project
